### PR TITLE
Auto-generate plot manifest from Examples/ directory

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -25,12 +25,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      
+      - name: Generate plots manifest
+        run: |
+          python3 generate_plots_manifest.py
         
       - name: Prepare site files
         run: |
           # Create a clean site directory with only the files needed for the website
           mkdir -p site
           cp index.html site/
+          cp plots.json site/
           cp -r Examples site/
           cp -r pandas_nhanes site/
           cp .nojekyll site/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 partial_results/*
 
+# Auto-generated files
+plots.json
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/AUTO_PLOT_MANIFEST.md
+++ b/AUTO_PLOT_MANIFEST.md
@@ -1,0 +1,58 @@
+# Automated Plot Manifest Generation
+
+## Problem
+Previously, when adding a new plot to the `Examples/` directory, you had to manually edit `index.html` and add the plot name to the hardcoded `plotExamples` array. This was error-prone and easy to forget.
+
+## Solution
+The plots are now automatically discovered and loaded dynamically:
+
+1. **`generate_plots_manifest.py`** - A Python script that scans the `Examples/` directory and generates `plots.json`
+2. **Updated `index.html`** - Now fetches plot information from `plots.json` instead of a hardcoded array
+3. **GitHub Actions integration** - The manifest is automatically regenerated on every push to `main`
+
+## How It Works
+
+### Automatic (GitHub Actions)
+Every time you push to `main`, the GitHub Pages workflow:
+1. Runs `generate_plots_manifest.py` to scan `Examples/` 
+2. Generates `plots.json` with all discovered plots
+3. Deploys the site with the updated manifest
+
+### Manual (Local Testing)
+To regenerate the manifest locally:
+```bash
+python3 generate_plots_manifest.py
+```
+
+This creates/updates `plots.json` with all plots found in `Examples/`.
+
+## Adding New Plots
+
+Simply add your plot to `Examples/`:
+```
+Examples/
+  └── YourNewPlot/
+      ├── YourNewPlot.png   (required)
+      ├── YourNewPlot.html  (optional)
+      └── YourNewPlot.py    (optional)
+```
+
+The script looks for:
+- **PNG file**: Either `<name>.png` or `plot.png` (required)
+- **HTML file**: Either `<name>.html` or `index.html` (optional)
+
+Push to GitHub, and your plot will automatically appear on the site!
+
+## File Structure
+
+- `generate_plots_manifest.py` - Manifest generator script
+- `plots.json` - Auto-generated manifest (gitignored, created by CI)
+- `index.html` - Updated to load plots dynamically from JSON
+
+## Benefits
+
+✅ No manual editing of `index.html` required  
+✅ Automatically discovers new plots  
+✅ Reduces human error  
+✅ Supports flexible naming conventions  
+✅ Works seamlessly with GitHub Pages deployment

--- a/generate_plots_manifest.py
+++ b/generate_plots_manifest.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Generate plots.json manifest from Examples/ directory.
+Scans for subdirectories containing .png and .html files.
+"""
+import json
+from pathlib import Path
+
+
+def find_plots(examples_dir="Examples"):
+    """Scan Examples/ directory and find all plot examples."""
+    examples_path = Path(examples_dir)
+    plots = []
+    
+    if not examples_path.exists():
+        print(f"Warning: {examples_dir} directory not found")
+        return plots
+    
+    # Iterate through subdirectories
+    for subdir in sorted(examples_path.iterdir()):
+        if not subdir.is_dir():
+            continue
+        
+        base_name = subdir.name
+        
+        # Look for PNG file (either <name>.png or plot.png)
+        png_candidates = [
+            subdir / f"{base_name}.png",
+            subdir / "plot.png",
+        ]
+        
+        png_file = None
+        for candidate in png_candidates:
+            if candidate.exists():
+                png_file = candidate
+                break
+        
+        # Look for HTML file (either <name>.html or index.html)
+        html_candidates = [
+            subdir / f"{base_name}.html",
+            subdir / "index.html",
+        ]
+        
+        html_file = None
+        for candidate in html_candidates:
+            if candidate.exists():
+                html_file = candidate
+                break
+        
+        # Only include if we have at least a PNG
+        if png_file:
+            plot_info = {
+                "base": base_name,
+                "png": png_file.relative_to(Path(".")).as_posix(),
+                "html": html_file.relative_to(Path(".")).as_posix() if html_file else None,
+            }
+            plots.append(plot_info)
+            print(f"✓ Found: {base_name}")
+        else:
+            print(f"⚠ Skipped {base_name} (no PNG found)")
+    
+    return plots
+
+
+def main():
+    plots = find_plots()
+    
+    # Write to plots.json
+    output_file = Path("plots.json")
+    with output_file.open("w") as f:
+        json.dump(plots, f, indent=2)
+    
+    print(f"\n✅ Generated {output_file} with {len(plots)} plots")
+
+
+if __name__ == "__main__":
+    main()

--- a/index.html
+++ b/index.html
@@ -458,14 +458,8 @@
 
     <script>
         // PNG/HTML pairs for carousel and modal
-        const plotExamples = [
-            { base: 'BMD_Age_Gender' },
-            { base: 'Cholesterol_Age' },
-            { base: 'Estradiol_Age_Gender' },
-            { base: 'Testosterone_Age_Gender' },
-            { base: 'Testosterone_Estrogen_Ratio' }
-        ];
-
+        // Dynamically loaded from plots.json
+        let plotExamples = [];
         let currentIndex = 0;
         let plotItems = [];
 
@@ -476,7 +470,7 @@ function loadImagesIndividually(plotExamples, baseWidth = 300) {
     plotItems = [];
     plotExamples.forEach((plot, index) => {
         const img = new window.Image();
-        img.src = `Examples/${plot.base}/${plot.base}.png`;
+        img.src = plot.png;
         img.alt = plot.base;
         img.onload = function() {
             const aspectRatio = img.naturalWidth / img.naturalHeight;
@@ -623,7 +617,7 @@ function loadImagesIndividually(plotExamples, baseWidth = 300) {
             // Add PNG image as background
             modalImg = document.createElement('img');
             modalImg.id = 'modal-img';
-            modalImg.src = `Examples/${plot.base}/${plot.base}.png`;
+            modalImg.src = plot.png;
             modalImg.alt = plot.base;
             modalImg.style.position = 'absolute';
             modalImg.style.top = '0';
@@ -640,8 +634,8 @@ function loadImagesIndividually(plotExamples, baseWidth = 300) {
             modal.classList.add('show');
             document.body.style.overflow = 'hidden';
             // Now load the HTML in the iframe, fade in when loaded
-            if (modalIframe) {
-                modalIframe.src = `Examples/${plot.base}/${plot.base}.html`;
+            if (modalIframe && plot.html) {
+                modalIframe.src = plot.html;
                 modalIframe.style.display = 'block';
                 modalIframe.classList.add('centered');
                 modalIframe.style.zIndex = '2';
@@ -712,7 +706,19 @@ function loadImagesIndividually(plotExamples, baseWidth = 300) {
         }
 
         document.addEventListener("DOMContentLoaded", function() {
-            createPlotThumbnails();
+            // Load plots from JSON manifest
+            fetch('plots.json')
+                .then(response => response.json())
+                .then(plots => {
+                    plotExamples = plots;
+                    createPlotThumbnails();
+                })
+                .catch(error => {
+                    console.error('Failed to load plots.json:', error);
+                    // Fallback to empty array
+                    plotExamples = [];
+                    createPlotThumbnails();
+                });
             // Removed prev/next button event listeners since buttons are gone
             document.addEventListener('keydown', (e) => {
                 if (e.key === 'ArrowLeft') {


### PR DESCRIPTION
## Summary
Fixes #3 - Avoid having to manually add plots to index.html when uploading a new one.

## Changes
- **New script**: `generate_plots_manifest.py` scans `Examples/` and generates `plots.json`
- **Updated `index.html`**: Now fetches plots dynamically from `plots.json` instead of hardcoded array
- **GitHub Actions**: Workflow now auto-generates manifest on every deploy
- **Documentation**: Added `AUTO_PLOT_MANIFEST.md` explaining the system

## How it works now
1. Add a new plot folder to `Examples/` with a PNG file
2. Push to main
3. GitHub Actions generates the manifest and deploys
4. Your plot automatically appears on the site!

No more manual editing of `index.html` 🎉